### PR TITLE
fixed the assembly name in the k2D2 plugin loading

### DIFF
--- a/src/FlightPlan/FPOtherModsInterface.cs
+++ b/src/FlightPlan/FPOtherModsInterface.cs
@@ -65,10 +65,17 @@ public class FPOtherModsInterface
             _k2d2VerCheck = _k2d2Info.Metadata.Version.CompareTo(_k2d2MinVersion);
             Logger.LogInfo($"_k2d2VerCheck = {_k2d2VerCheck}");
             string _toolTip;
-            if (_k2d2VerCheck >= 0) _toolTip = "Have K2-D2 Execute this node";
-            else _toolTip = "Launch K2-D2";
+            if (_k2d2VerCheck >= 0) 
+                _toolTip = "Have K2-D2 Execute this node";
+            else 
+                _toolTip = "Launch K2-D2";
 
-            K2D2Type = Type.GetType($"K2D2.K2D2_Plugin, {K2D2ModGuid}");
+            var assembly_name = K2D2ModGuid;
+            var is_new_version = _k2d2Info.Metadata.Version.CompareTo(new Version(1, 0, 0));
+            if (is_new_version >= 0) 
+                assembly_name = "K2D2";
+
+            K2D2Type = Type.GetType($"K2D2.K2D2_Plugin, {assembly_name}");
             K2D2PropertyInfo = K2D2Type!.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static);
             K2D2Instance = K2D2PropertyInfo.GetValue(null);
             K2D2ToggleMethodInfo = K2D2PropertyInfo!.PropertyType.GetMethod("ToggleAppBarButton");


### PR DESCRIPTION
I think it keeps the compatibility with older k2d2 versions. and is now ready to fit new corrected version of assembly